### PR TITLE
Adding Group resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [Provider](#Provider)
 
+* [onepassword_group](#onepassword_group)
 * [onepassword_vault](#onepassword_vault)
 * [onepassword_item_common](#onepassword_item_common)
 * [onepassword_item_document](#onepassword_item_document)
@@ -42,6 +43,46 @@ The following arguments are supported:
 * `subdomain` - (Optional) If you use corporate account you must fill subdomain form your 1password site. Defaults to `my` or via env variable `OP_SUBDOMAIN`.
 
 If `email`, `password` and `secret_key` is not set through the arguments or env variables, then the env variable `OP_SESSION_<subdomain>` is checked for existence. If set it will be assumed to be a valid session token and used while executing the `op` commands.
+
+## onepassword_group
+
+This resource can create/load groups in your 1Password account.
+
+### Example Usage
+
+#### Resource
+
+```hcl
+resource "onepassword_group" "this" {
+    name = "new-group"
+}
+```
+
+#### Data Source
+
+```hcl
+data "onepassword_group" "this" {
+    name = "exist-group"
+}
+```
+
+### Argument Reference
+
+* `name` - (Required) group name.
+
+### Attribute Reference
+
+* `id` - (Required) group id.
+
+*Note: and all from arguments.*
+
+### Import
+
+1Password Groups can be imported using the `id`, e.g.
+
+```
+terraform import onepassword_group.group 7kalogoe3kirwf5aizotkbzrpq
+```
 
 ## onepassword_vault
 

--- a/examples012/group/main.tf
+++ b/examples012/group/main.tf
@@ -1,0 +1,7 @@
+data "onepassword_group" "this" {
+  name = var.exist_group_name
+}
+
+resource "onepassword_group" "this" {
+  name = var.new_group_name
+}

--- a/examples012/group/output.tf
+++ b/examples012/group/output.tf
@@ -1,0 +1,7 @@
+output "team" {
+  value = data.onepassword_group.this.id
+}
+
+output "new" {
+  value = onepassword_group.this.id
+}

--- a/examples012/group/variables.tf
+++ b/examples012/group/variables.tf
@@ -1,0 +1,7 @@
+variable "exist_group_name" {
+  default = "Team Members"
+}
+
+variable "new_group_name" {
+  default = "New"
+}

--- a/examples012/main.tf
+++ b/examples012/main.tf
@@ -9,6 +9,10 @@ resource "random_string" "password" {
   length = "32"
 }
 
+module "group" {
+  source = "./group"
+}
+
 module "vault" {
   source = "../examples/vault"
 }

--- a/onepassword/data_group.go
+++ b/onepassword/data_group.go
@@ -1,0 +1,10 @@
+package onepassword
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func dataSourceGroup() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceGroupRead,
+		Schema: resourceGroup().Schema,
+	}
+}

--- a/onepassword/group.go
+++ b/onepassword/group.go
@@ -1,0 +1,54 @@
+package onepassword
+
+import (
+	"encoding/json"
+)
+
+const (
+	// GroupResource is 1Password's internal designator for Groups
+	GroupResource = "group"
+
+	// GroupStateActive indicates an Active Group
+	GroupStateActive = "A"
+
+	// GroupStateDeleted indicates a Deleted Group
+	GroupStateDeleted = "D"
+)
+
+// Group represents a 1Password Group resource
+type Group struct {
+	UUID  string
+	Name  string
+	State string
+}
+
+// ReadGroup gets an existing 1Password Group
+func (o *OnePassClient) ReadGroup(id string) (*Group, error) {
+	group := &Group{}
+	res, err := o.runCmd(opPasswordGet, GroupResource, id)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(res, group); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+// CreateGroup creates a new 1Password Group
+func (o *OnePassClient) CreateGroup(v *Group) (*Group, error) {
+	args := []string{opPasswordCreate, GroupResource, v.Name}
+	res, err := o.runCmd(args...)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(res, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// DeleteGroup deletes a 1Password Group
+func (o *OnePassClient) DeleteGroup(id string) error {
+	return o.Delete(GroupResource, id)
+}

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"onepassword_group":                 resourceGroup(),
 			"onepassword_item_common":           resourceItemCommon(),
 			"onepassword_item_software_license": resourceItemSoftwareLicense(),
 			"onepassword_item_identity":         resourceItemIdentity(),
@@ -61,6 +62,7 @@ func Provider() terraform.ResourceProvider {
 			"onepassword_vault":                 resourceVault(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"onepassword_group":                 dataSourceGroup(),
 			"onepassword_item_common":           dataSourceItemCommon(),
 			"onepassword_item_software_license": dataSourceItemSoftwareLicense(),
 			"onepassword_item_identity":         dataSourceItemIdentity(),

--- a/onepassword/resource_group.go
+++ b/onepassword/resource_group.go
@@ -36,7 +36,10 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(v.UUID)
-	d.Set("name", v.Name)
+	if err := d.Set("name", v.Name); err != nil {
+		return err
+	}
+
 	return d.Set("state", v.State)
 }
 

--- a/onepassword/resource_group.go
+++ b/onepassword/resource_group.go
@@ -1,0 +1,61 @@
+package onepassword
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGroup() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceGroupRead,
+		Create: resourceGroupCreate,
+		Delete: resourceGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				err := resourceGroupRead(d, meta)
+				return []*schema.ResourceData{d}, err
+			},
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
+	m := meta.(*Meta)
+	v, err := m.onePassClient.ReadGroup(getID(d))
+	if err != nil {
+		return err
+	} else if v.State == GroupStateDeleted {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(v.UUID)
+	d.Set("name", v.Name)
+	return d.Set("state", v.State)
+}
+
+func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	m := meta.(*Meta)
+	_, err := m.onePassClient.CreateGroup(&Group{
+		Name: d.Get("name").(string),
+	})
+	if err != nil {
+		return err
+	}
+	return resourceGroupRead(d, meta)
+}
+
+func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	m := meta.(*Meta)
+	err := m.onePassClient.DeleteGroup(getID(d))
+	if err == nil {
+		d.SetId("")
+	}
+	return err
+}


### PR DESCRIPTION
Fixes #18 

## Proposed Changes

* Adds a `group` resource to the provider, taking inspiration from the existing `vault` resource.
* Leaving additional items such as Group Membership and Group-Vault associations to later resources.
* Note that this implementation tracks the `state` JSON property which helps determine if the group has been deleted or not. This might assist with solving #17.