### PR TITLE
Add group_member resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Provider
 
-Terraform provider for 1password usage with your infrastructure, for example you can share password from your admin panel via some vault in you 1password company account. This provider is based on 1Password CLI client version 0.5.5, but you can rewrite it by env variable `OP_VERSION`.
+Terraform provider for 1password usage with your infrastructure, for example you can share password from your admin panel via some vault in you 1password company account. This provider is based on 1Password CLI client version 1.4.0, but you can rewrite it by env variable `OP_VERSION`.
 
 ## Example Usage
 

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -1,0 +1,43 @@
+# onepassword_group_member
+
+This resource can manage group membership within a 1Password group.
+
+## Example Usage
+
+### Resource
+
+```hcl
+resource "onepassword_group" "group" {
+    group = "new-group"
+}
+
+data "onepassword_user" "user" {
+    email = "example@example.com"
+}
+
+resource "onepassword_group_member" "example" {
+    group = onepassword_group.group.id
+    user = data.onepassword_user.user.id
+}
+```
+
+## Argument Reference
+
+* `group` - (Required) group id.
+* `user` - (Required) user id.
+
+## Attribute Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - (Required) internal membership identifier.
+
+## Import
+
+1Password Group Members can be imported using the `id`, which consists of the group ID and user ID separated by a hyphen, e.g.
+
+```
+terraform import onepassword_group_member.example fmownretj6zdobn2cnjtqqyrae-KDLG56VTIJDXXBXC2KKCPHNHHI
+```
+
+**Note: this is case sensitive, and matches the case provided by 1Password.**

--- a/onepassword/group_test.go
+++ b/onepassword/group_test.go
@@ -268,3 +268,181 @@ func TestOnePassClient_DeleteGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestOnePassClient_ListGroupMembers(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		want            []User
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `[ { "uuid": "uniq", "firstname": "Testy", "lastname": "Testerton" } ]`, nil
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "list", "users", "--group", "uniq", "--session="},
+			want:            []User{{UUID: "uniq", FirstName: "Testy", LastName: "Testerton"}},
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "list", "users", "--group", "uniq", "--session="},
+			wantErr:         true,
+		},
+		{
+			name:    "error-missing-id",
+			args:    args{id: ""},
+			want:    []User{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			got, err := o.ListGroupMembers(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.ListGroupMembers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OnePassClient.ListGroupMembers() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.ListGroupMembers() exec = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}
+
+func TestOnePassClient_CreateGroupMember(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		userID  string
+		groupID string
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ }`, nil
+				},
+			},
+			args:            args{userID: "userName", groupID: "groupName"},
+			wantExecResults: []string{"op", "add", "user", "groupName", "userName", "--session="},
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{userID: "userName", groupID: "groupName"},
+			wantExecResults: []string{"op", "add", "user", "groupName", "userName", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			err := o.CreateGroupMember(tt.args.userID, tt.args.groupID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.ListGroupMembers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.ListGroupMembers() exec = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}
+
+func TestOnePassClient_DeleteGroupMember(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		userID  string
+		groupID string
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ }`, nil
+				},
+			},
+			args:            args{userID: "userName", groupID: "groupName"},
+			wantExecResults: []string{"op", "remove", "user", "groupName", "userName", "--session="},
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{userID: "userName", groupID: "groupName"},
+			wantExecResults: []string{"op", "remove", "user", "groupName", "userName", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			err := o.DeleteGroupMember(tt.args.userID, tt.args.groupID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.ListGroupMembers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.ListGroupMembers() exec = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"onepassword_group":                 resourceGroup(),
+			"onepassword_group_member":          resourceGroupMember(),
 			"onepassword_item_common":           resourceItemCommon(),
 			"onepassword_item_software_license": resourceItemSoftwareLicense(),
 			"onepassword_item_identity":         resourceItemIdentity(),
@@ -89,10 +90,15 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	return NewMeta(d)
 }
 
-const opPasswordCreate = "create"
-const opPasswordEdit = "edit"
-const opPasswordDelete = "delete"
-const opPasswordGet = "get"
+const (
+	opPasswordAdd    = "add"
+	opPasswordCreate = "create"
+	opPasswordEdit   = "edit"
+	opPasswordDelete = "delete"
+	opPasswordGet    = "get"
+	opPasswordList   = "list"
+	opPasswordRemove = "remove"
+)
 
 type OnePassClient struct {
 	Password    string

--- a/onepassword/resource_group_member.go
+++ b/onepassword/resource_group_member.go
@@ -1,0 +1,116 @@
+package onepassword
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGroupMember() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceGroupMemberRead,
+		CreateContext: resourceGroupMemberCreate,
+		DeleteContext: resourceGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"group": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"user": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceGroupMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	groupID, userID, err := resourceGroupMemberExtractID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	m := meta.(*Meta)
+	v, err := m.onePassClient.ListGroupMembers(groupID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var found string
+	for _, member := range v {
+		if member.UUID == userID {
+			found = member.UUID
+		}
+	}
+
+	if found == "" {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(resourceGroupMemberBuildID(groupID, found))
+	d.Set("group", groupID)
+	d.Set("user", found)
+	return nil
+}
+
+func resourceGroupMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	m := meta.(*Meta)
+	err := m.onePassClient.CreateGroupMember(
+		d.Get("group").(string),
+		d.Get("user").(string),
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resourceGroupMemberBuildID(d.Get("group").(string), d.Get("user").(string)))
+	return resourceGroupMemberRead(ctx, d, meta)
+}
+
+func resourceGroupMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	groupID, userID, err := resourceGroupMemberExtractID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	m := meta.(*Meta)
+	err = m.onePassClient.DeleteGroupMember(
+		groupID,
+		userID,
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// resourceGroupMemberBuildID will conjoin the group ID and user ID into a single string
+// This is used as the resource ID.
+//
+// Note that user ID is being lowercased. Some operations require this user ID to be uppercased.
+// Use the resourceGroupMemberExtractID function to correctly reverse this encoding.
+func resourceGroupMemberBuildID(groupID, userID string) string {
+	return strings.ToLower(groupID + "-" + strings.ToLower(userID))
+}
+
+// resourceGroupMemberExtractID will split the group ID and user ID from a given resource ID
+//
+// Note that user ID is being uppercased. Some operations require this user ID to be uppercased.
+func resourceGroupMemberExtractID(id string) (groupID, userID string, err error) {
+	spl := strings.Split(id, "-")
+	if len(spl) != 2 {
+		return "", "", fmt.Errorf("Improperly formatted group member string. The format \"groupid-userid\" is expected")
+	}
+	return spl[0], strings.ToUpper(spl[1]), nil
+}

--- a/onepassword/resource_group_member_test.go
+++ b/onepassword/resource_group_member_test.go
@@ -1,0 +1,32 @@
+package onepassword
+
+import "testing"
+
+func Test_resourceGroupMemberBuildID(t *testing.T) {
+	want := "v3zk6wiptl42r7cmzbmf23unny-tgkw5a3cpbcu5end3lld3wckxi"
+	got := resourceGroupMemberBuildID("v3zk6wiptl42r7cmzbmf23unny", "TGKW5A3CPBCU5END3LLD3WCKXI")
+
+	if want != got {
+		t.Error("Did not correctly conjoin the group and user IDs: " + got)
+	}
+}
+
+func Test_resourceGroupMemberExtractID(t *testing.T) {
+	wantGroup := "v3zk6wiptl42r7cmzbmf23unny"
+	wantUser := "TGKW5A3CPBCU5END3LLD3WCKXI"
+	gotGroup, gotUser, err := resourceGroupMemberExtractID("v3zk6wiptl42r7cmzbmf23unny-tgkw5a3cpbcu5end3lld3wckxi")
+
+	if err != nil {
+		t.Error(err)
+	} else if wantGroup != gotGroup {
+		t.Error("Did not correctly extract the group ID: " + gotGroup)
+	} else if wantUser != gotUser {
+		t.Error("Did not correctly extract the user ID: " + gotUser)
+	}
+
+	// Test malformed ID
+	_, _, err = resourceGroupMemberExtractID("totally not the right id")
+	if err == nil {
+		t.Error("Error was not returned from malformed id")
+	}
+}


### PR DESCRIPTION
Fixes #44 

## Proposed Changes

* Adds a `onepassword_group_member` resource for managing group membership within a 1Password installation.
* This bumps the required version of the `op` client to 1.4.0 so that it receives the [bug fixes](https://discussions.agilebits.com/discussion/comment/565941) applied to that version. In testing I also found that the automatic installation will not work on Mac due to their versions being distributed in a `.pkg` installer; I added error handling to more cleanly instruct the user in that case.

## TODO

- [x] Import the changes from the terraform sdk v2 upgrade
- [x] Test a possible panic if someone attempts to `import` but doesn't use the hyphenated syntax
- [x] Update the [required op version](https://github.com/anasinnyk/terraform-provider-1password/blob/master/onepassword/provider.go#L23), as there is a bug fix inbound that only the newest client will contain.
