### PR TITLE
Support Group Renames; Address Group State issue

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -19,11 +19,4 @@ data "onepassword_group" "this" {
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - group id.
-
-## Import
-
-1Password Groups can be imported using the `id`, e.g.
-
-```
-terraform import onepassword_group.group 7kalogoe3kirwf5aizotkbzrpq
-```
+* `state` - current state of the group. "A" for active, "D" for deleted.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -19,6 +19,7 @@ resource "onepassword_group" "this" {
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - group id.
+* `state` - current state of the group. "A" for active, "D" for deleted.
 
 ## Import
 

--- a/onepassword/group.go
+++ b/onepassword/group.go
@@ -48,6 +48,13 @@ func (o *OnePassClient) CreateGroup(v *Group) (*Group, error) {
 	return v, nil
 }
 
+// UpdateGroup updates an existing 1Password Group
+func (o *OnePassClient) UpdateGroup(id string, v *Group) error {
+	args := []string{opPasswordEdit, GroupResource, id, "--name=" + v.Name}
+	_, err := o.runCmd(args...)
+	return err
+}
+
 // DeleteGroup deletes a 1Password Group
 func (o *OnePassClient) DeleteGroup(id string) error {
 	return o.Delete(GroupResource, id)

--- a/onepassword/group_test.go
+++ b/onepassword/group_test.go
@@ -1,0 +1,270 @@
+package onepassword
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestOnePassClient_ReadGroup(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		want            *Group
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ "uuid": "uniq", "name": "foo" }`, nil
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "get", "group", "uniq", "--session="},
+			want:            &Group{UUID: "uniq", Name: "foo"},
+		},
+		{
+			name: "bad json",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `This was supposed to be JSON`, nil
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "get", "group", "uniq", "--session="},
+			wantErr:         true,
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "get", "group", "uniq", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			got, err := o.ReadGroup(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.ReadGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OnePassClient.ReadGroup() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.ReadGroup() = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}
+
+func TestOnePassClient_CreateGroup(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		v *Group
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		want            *Group
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ "uuid": "uniq", "name": "foo" }`, nil
+				},
+			},
+			args:            args{v: &Group{Name: "foo"}},
+			wantExecResults: []string{"op", "create", "group", "foo", "--session="},
+			want:            &Group{UUID: "uniq", Name: "foo"},
+		},
+		{
+			name: "bad json",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `This was supposed to be JSON`, nil
+				},
+			},
+			args:            args{v: &Group{Name: "foo"}},
+			wantExecResults: []string{"op", "create", "group", "foo", "--session="},
+			wantErr:         true,
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{v: &Group{Name: "foo"}},
+			wantExecResults: []string{"op", "create", "group", "foo", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			got, err := o.CreateGroup(tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.CreateGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OnePassClient.CreateGroup() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.CreateGroup() = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}
+
+func TestOnePassClient_UpdateGroup(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		id string
+		v  *Group
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		want            *Group
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ "uuid": "uniq", "name": "foo" }`, nil
+				},
+			},
+			args: args{
+				id: "uniq",
+				v:  &Group{Name: "foo"},
+			},
+			wantExecResults: []string{"op", "edit", "group", "uniq", "--name=foo", "--session="},
+			want:            &Group{UUID: "uniq", Name: "foo"},
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args: args{
+				id: "uniq",
+				v:  &Group{Name: "foo"},
+			},
+			wantExecResults: []string{"op", "edit", "group", "uniq", "--name=foo", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			err := o.UpdateGroup(tt.args.id, tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.UpdateGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.UpdateGroup() = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}
+
+func TestOnePassClient_DeleteGroup(t *testing.T) {
+	type fields struct {
+		runCmd func() (string, error)
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantExecResults []string
+		want            *Group
+		wantErr         bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return `{ "uuid": "uniq", "name": "foo" }`, nil
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "delete", "group", "uniq", "--session="},
+			want:            &Group{UUID: "uniq", Name: "foo"},
+		},
+		{
+			name: "error",
+			fields: fields{
+				runCmd: func() (string, error) {
+					return ``, fmt.Errorf("oops")
+				},
+			},
+			args:            args{id: "uniq"},
+			wantExecResults: []string{"op", "delete", "group", "uniq", "--session="},
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &mockOnePassConfig{
+				runCmd: tt.fields.runCmd,
+			}
+			o := mockOnePassClient(config)
+
+			err := o.DeleteGroup(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnePassClient.DeleteGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(config.execCommandResults, tt.wantExecResults) {
+				t.Errorf("OnePassClient.DeleteGroup() = %v, want %v", config.execCommandResults, tt.wantExecResults)
+			}
+		})
+	}
+}

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -89,6 +89,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 const opPasswordCreate = "create"
+const opPasswordEdit = "edit"
 const opPasswordDelete = "delete"
 const opPasswordGet = "get"
 

--- a/onepassword/provider_test.go
+++ b/onepassword/provider_test.go
@@ -1,0 +1,33 @@
+package onepassword
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+type mockOnePassConfig struct {
+	runCmd             func() (string, error)
+	execCommandResults []string // Populated when execCommand is executed so you can assert against the args passed in
+}
+
+func mockOnePassClient(params *mockOnePassConfig) *OnePassClient {
+	ret := &OnePassClient{
+		PathToOp: "op",
+		mutex:    &sync.Mutex{},
+	}
+
+	if params.runCmd != nil {
+		ret.execCommand = func(binary string, args ...string) *exec.Cmd {
+			params.execCommandResults = append([]string{binary}, args...)
+
+			out, err := params.runCmd()
+			if err != nil {
+				return exec.Command("sh", "-c", "echo "+strings.ReplaceAll(err.Error(), `"`, `\"`)+" && false")
+			}
+			return exec.Command("sh", "-c", "echo "+strings.ReplaceAll(out, `"`, `\"`))
+		}
+	}
+
+	return ret
+}

--- a/onepassword/resource_group.go
+++ b/onepassword/resource_group.go
@@ -8,6 +8,7 @@ func resourceGroup() *schema.Resource {
 	return &schema.Resource{
 		Read:   resourceGroupRead,
 		Create: resourceGroupCreate,
+		Update: resourceGroupUpdate,
 		Delete: resourceGroupDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
@@ -18,7 +19,6 @@ func resourceGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Required: true,
 			},
 			"state": {
@@ -65,4 +65,17 @@ func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 	}
 	return err
+}
+
+func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	m := meta.(*Meta)
+
+	g := &Group{
+		Name: d.Get("name").(string),
+	}
+
+	if err := m.onePassClient.UpdateGroup(getID(d), g); err != nil {
+		return err
+	}
+	return resourceGroupRead(d, meta)
 }

--- a/onepassword/resource_group.go
+++ b/onepassword/resource_group.go
@@ -21,6 +21,10 @@ func resourceGroup() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Proposed Changes

  - Fixed an issue with [State being set](https://github.com/anasinnyk/terraform-provider-1password/blob/2fa4fb79516af033dc9be79c40cb0d9ea576bdab/onepassword/resource_group.go#L47) in the Read action, but not being present in the schema. Added it as a Computed field.
  - Added an Updater for Groups, allowing users to modify the "name" field.
  - To boost my confidence, wrote some initial unit tests. These appear to be the first in the repository -- @anasinnyk if you feel test maintenance is burdensome or otherwise not welcome I can remove them!
