### PR TITLE
document: add support for binary docs as b64

### DIFF
--- a/docs/data-sources/item_document.md
+++ b/docs/data-sources/item_document.md
@@ -13,7 +13,7 @@ data "onepassword_item_document" "this" {
 ## Argument Reference
 
 * `name` - (Required) your document title.
-* `field_path` - (Required) path to your document, which will be upload to 1password.
+* `binary` - (Optional) set to true if your document is binary. Default: false.
 * `vault` - (Optional) see details in onepassword_item_common.
 * `notes` - (Optional) see details in onepassword_item_common.
 * `tags` - (Optional) see details in onepassword_item_common.
@@ -24,4 +24,4 @@ data "onepassword_item_document" "this" {
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - document id.
-* `content` - document content.
+* `content` - document content. If `binary` is true, this is a base64 encoded string.

--- a/docs/resources/item_document.md
+++ b/docs/resources/item_document.md
@@ -16,6 +16,7 @@ resource "onepassword_item_document" "this" {
 
 * `name` - (Required) your document title.
 * `field_path` - (Required) path to your document, which will be upload to 1password.
+* `binary` - (Optional) set to true if your document is binary. Default: false.
 * `vault` - (Optional) see details in onepassword_item_common.
 * `notes` - (Optional) see details in onepassword_item_common.
 * `tags` - (Optional) see details in onepassword_item_common.
@@ -26,4 +27,4 @@ resource "onepassword_item_document" "this" {
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - document id.
-* `content` - document content.
+* `content` - document content. If `binary` is true, this is a base64 encoded string.

--- a/onepassword/item.go
+++ b/onepassword/item.go
@@ -2,6 +2,7 @@ package onepassword
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -275,13 +276,21 @@ func (o *OnePassClient) CreateItem(v *Item) error {
 	return err
 }
 
-func (o *OnePassClient) ReadDocument(id string) (string, error) {
+func (o *OnePassClient) ReadDocument(id string, binary bool) (string, error) {
 	content, err := o.runCmd(
 		opPasswordGet,
 		DocumentResource,
 		id,
 	)
-	return string(content), err
+	if err != nil {
+		return "", err
+	}
+
+	if binary {
+		return base64.StdEncoding.EncodeToString(content), nil
+	}
+
+	return string(content), nil
 }
 
 func (o *OnePassClient) CreateDocument(v *Item, filePath string) error {

--- a/onepassword/resource_item_document.go
+++ b/onepassword/resource_item_document.go
@@ -48,6 +48,12 @@ func resourceItemDocument() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"binary": {
+				Type:     schema.TypeBool,
+				ForceNew: true,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -74,7 +80,7 @@ func resourceItemDocumentRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	content, err := m.onePassClient.ReadDocument(v.UUID)
+	content, err := m.onePassClient.ReadDocument(v.UUID, d.Get("binary").(bool))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -98,7 +104,7 @@ func resourceItemDocumentCreate(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	content, err := m.onePassClient.ReadDocument(item.UUID)
+	content, err := m.onePassClient.ReadDocument(item.UUID, d.Get("binary").(bool))
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
This adds a `binary` attribute to `data.onepassword_item_document` that can be set for a document that has binary content. When `binary = true`, the client will base64 encode the resulting output bytes so that it can be [handled by Terraform](https://www.terraform.io/docs/language/functions/filebase64.html). This allows binary documents stored in 1Password to be passed to other Terraform resources that support binary data such as [`local_file`](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file#content_base64) and [`aws_s3_bucket_object`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#content_base64).